### PR TITLE
Feature/pit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ KERNEL_C_SOURCES = $(KERNEL_MAIN) \
                    $(KERNEL_SRC_DIR)/process/process.c \
                    $(KERNEL_SRC_DIR)/syscalls/syscalls.c \
                    $(KERNEL_SRC_DIR)/storage/hdd.c \
-                   $(KERNEL_SRC_DIR)/storage/fat32.c
+                   $(KERNEL_SRC_DIR)/storage/fat32.c \
+                   $(KERNEL_SRC_DIR)/timer/pit.c
 
 # Assembly source files
 KERNEL_ASM_SOURCES = $(KERNEL_ENTRY) \
@@ -65,7 +66,8 @@ KERNEL_C_OBJS = $(BUILD_DIR)/kernel_main.o \
                 $(BUILD_DIR)/process.o \
                 $(BUILD_DIR)/syscalls.o \
                 $(BUILD_DIR)/hdd.o \
-                $(BUILD_DIR)/fat32.o
+                $(BUILD_DIR)/fat32.o \
+                $(BUILD_DIR)/pit.o
 
 KERNEL_ASM_OBJS = $(BUILD_DIR)/interrupt_handlers_asm.o \
                   $(BUILD_DIR)/context_switch.o
@@ -175,6 +177,10 @@ $(BUILD_DIR)/hdd.o: $(KERNEL_SRC_DIR)/storage/hdd.c | $(BUILD_DIR)
 
 # Build fat32.c
 $(BUILD_DIR)/fat32.o: $(KERNEL_SRC_DIR)/storage/fat32.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $@ $<
+
+# Build pit.c
+$(BUILD_DIR)/pit.o: $(KERNEL_SRC_DIR)/timer/pit.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -o $@ $<
 
 # Build context_switch.asm

--- a/boot/stage2.asm
+++ b/boot/stage2.asm
@@ -9,7 +9,7 @@
 
 ; === Constants ===
 KERNEL_OFFSET equ 0x10000       ; Load kernel at 64KB (safe location)
-KERNEL_SECTORS equ 85           ; Max sectors for kernel (85 * 512 = 43680 bytes)
+KERNEL_SECTORS equ 90           ; Max sectors for kernel (90 * 512 = 46080 bytes)
 KERNEL_START_SECTOR equ 11      ; Kernel starts at sector 11
 
 ; GDT segment selectors

--- a/kernel/include/timer/pit.h
+++ b/kernel/include/timer/pit.h
@@ -1,0 +1,66 @@
+#ifndef PIT_H
+#define PIT_H
+
+#include "../common/types.h"
+
+/* PIT (Programmable Interval Timer) 8253/8254 chip */
+
+/* PIT I/O ports */
+#define PIT_CHANNEL_0_DATA      0x40    /* Channel 0 data port (system timer) */
+#define PIT_CHANNEL_1_DATA      0x41    /* Channel 1 data port (RAM refresh) */
+#define PIT_CHANNEL_2_DATA      0x42    /* Channel 2 data port (PC speaker) */
+#define PIT_COMMAND_PORT        0x43    /* Command/mode control port */
+
+/* PIT operating modes */
+#define PIT_MODE_0              0x00    /* Interrupt on terminal count */
+#define PIT_MODE_1              0x02    /* Hardware retriggerable one-shot */
+#define PIT_MODE_2              0x04    /* Rate generator */
+#define PIT_MODE_3              0x06    /* Square wave generator */
+#define PIT_MODE_4              0x08    /* Software triggered strobe */
+#define PIT_MODE_5              0x0A    /* Hardware triggered strobe */
+
+/* PIT access modes */
+#define PIT_ACCESS_LATCH        0x00    /* Latch count value command */
+#define PIT_ACCESS_LOBYTE       0x10    /* Access low byte only */
+#define PIT_ACCESS_HIBYTE       0x20    /* Access high byte only */
+#define PIT_ACCESS_LOHIBYTE     0x30    /* Access low byte then high byte */
+
+/* PIT channel select */
+#define PIT_CHANNEL_0           0x00    /* Select counter 0 */
+#define PIT_CHANNEL_1           0x40    /* Select counter 1 */
+#define PIT_CHANNEL_2           0x80    /* Select counter 2 */
+
+/* PIT binary/BCD mode */
+#define PIT_BINARY_MODE         0x00    /* Binary mode */
+#define PIT_BCD_MODE            0x01    /* BCD mode */
+
+/* Standard PIT frequency and common timer frequencies */
+#define PIT_BASE_FREQUENCY      1193182 /* Base frequency of PIT (approximately 1.193182 MHz) */
+#define TIMER_FREQUENCY_1000HZ  1000    /* 1000 Hz = 1ms intervals */
+#define TIMER_FREQUENCY_100HZ   100     /* 100 Hz = 10ms intervals */
+#define TIMER_FREQUENCY_50HZ    50      /* 50 Hz = 20ms intervals */
+#define TIMER_FREQUENCY_18HZ    18      /* 18.2 Hz = default BIOS frequency */
+
+/* Timer variables */
+extern volatile uint32_t system_ticks;      /* System timer tick counter */
+extern volatile uint32_t timer_frequency;   /* Current timer frequency in Hz */
+
+/* Function prototypes */
+void pit_initialize(void);
+void pit_set_frequency(uint32_t frequency);
+uint32_t pit_calculate_divisor(uint32_t frequency);
+void pit_set_divisor(uint16_t divisor);
+void timer_tick(void);
+uint32_t timer_get_ticks(void);
+uint32_t timer_get_seconds(void);
+uint32_t timer_get_milliseconds(void);
+void timer_reset(void);
+
+/* Timer callback function type */
+typedef void (*timer_callback_t)(void);
+
+/* Timer callback management */
+void timer_set_callback(timer_callback_t callback);
+void timer_clear_callback(void);
+
+#endif /* PIT_H */

--- a/kernel/src/interrupts/interrupt_handlers.c
+++ b/kernel/src/interrupts/interrupt_handlers.c
@@ -3,6 +3,7 @@
 #include "../../include/common/utils.h"
 #include "../../include/keyboard/keyboard.h"
 #include "../../include/process/process.h"
+#include "../../include/timer/pit.h"
 
 /* Helper function to send EOI signal to PIC */
 static inline void send_eoi(uint32_t int_no) {
@@ -18,6 +19,9 @@ static inline void send_eoi(uint32_t int_no) {
 
 /* Timer interrupt handler */
 void c_irq_handler_timer(void) {
+    /* Update timer tick count */
+    timer_tick();
+    
     /* Handle process scheduling on timer tick */
     scheduler_tick();
     

--- a/kernel/src/timer/pit.c
+++ b/kernel/src/timer/pit.c
@@ -1,0 +1,187 @@
+#include "../../include/timer/pit.h"
+#include "../../include/terminal/terminal.h"
+#include "../../include/common/utils.h"
+
+/* Global timer variables */
+volatile uint32_t system_ticks = 0;         /* Number of timer ticks since boot */
+volatile uint32_t timer_frequency = 0;      /* Current timer frequency */
+static timer_callback_t timer_callback = NULL; /* Optional timer callback */
+
+/* Port I/O helper functions */
+static inline void outb(uint16_t port, uint8_t val) {
+    __asm__ volatile("outb %0, %1" : : "a"(val), "Nd"(port));
+}
+
+static inline uint8_t inb(uint16_t port) {
+    uint8_t ret;
+    __asm__ volatile("inb %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+/* Initialize PIT with default frequency */
+void pit_initialize(void) {
+    terminal_writeline("Initializing PIT (Programmable Interval Timer)...");
+    
+    /* Reset system tick counter */
+    system_ticks = 0;
+    timer_callback = NULL;
+    
+    /* Set default timer frequency to 1000 Hz (1ms intervals) */
+    pit_set_frequency(TIMER_FREQUENCY_1000HZ);
+    
+    terminal_writeline("PIT initialized successfully!");
+    
+    char freq_str[32];
+    strcpy(freq_str, "Timer frequency set to: ");
+    char num_str[16];
+    int_to_string(timer_frequency, num_str);
+    strcat(freq_str, num_str);
+    strcat(freq_str, " Hz");
+    terminal_writeline(freq_str);
+}
+
+/* Set timer frequency */
+void pit_set_frequency(uint32_t frequency) {
+    if (frequency == 0) {
+        terminal_writeline("Error: Timer frequency cannot be zero!");
+        return;
+    }
+    
+    /* Calculate divisor */
+    uint16_t divisor = pit_calculate_divisor(frequency);
+    
+    /* Set the divisor */
+    pit_set_divisor(divisor);
+    
+    /* Store the actual frequency */
+    timer_frequency = PIT_BASE_FREQUENCY / divisor;
+    
+    char msg[64];
+    strcpy(msg, "Timer frequency changed to ");
+    char freq_str[16];
+    int_to_string(timer_frequency, freq_str);
+    strcat(msg, freq_str);
+    strcat(msg, " Hz");
+    terminal_writeline(msg);
+}
+
+/* Calculate divisor for given frequency */
+uint32_t pit_calculate_divisor(uint32_t frequency) {
+    if (frequency == 0) {
+        return 65535; /* Maximum divisor for minimum frequency */
+    }
+    
+    uint32_t divisor = PIT_BASE_FREQUENCY / frequency;
+    
+    /* Clamp divisor to valid range (1-65535) */
+    if (divisor == 0) {
+        divisor = 1;
+    } else if (divisor > 65535) {
+        divisor = 65535;
+    }
+    
+    return divisor;
+}
+
+/* Set PIT divisor directly */
+void pit_set_divisor(uint16_t divisor) {
+    /* Disable interrupts during PIT programming */
+    __asm__ volatile("cli");
+    
+    /* Send command byte to PIT command port */
+    /* Channel 0, Access mode: lobyte/hibyte, Mode 3: square wave, Binary mode */
+    uint8_t command = PIT_CHANNEL_0 | PIT_ACCESS_LOHIBYTE | PIT_MODE_3 | PIT_BINARY_MODE;
+    outb(PIT_COMMAND_PORT, command);
+    
+    /* Send divisor low byte first, then high byte */
+    outb(PIT_CHANNEL_0_DATA, divisor & 0xFF);        /* Low byte */
+    outb(PIT_CHANNEL_0_DATA, (divisor >> 8) & 0xFF); /* High byte */
+    
+    /* Re-enable interrupts */
+    __asm__ volatile("sti");
+}
+
+/* Get current tick count */
+uint32_t timer_get_ticks(void) {
+    return system_ticks;
+}
+
+/* Get seconds since boot */
+uint32_t timer_get_seconds(void) {
+    if (timer_frequency == 0) return 0;
+    return system_ticks / timer_frequency;
+}
+
+/* Get milliseconds since boot */
+uint32_t timer_get_milliseconds(void) {
+    if (timer_frequency == 0) return 0;
+    return (system_ticks * 1000) / timer_frequency;
+}
+
+/* Reset timer counter */
+void timer_reset(void) {
+    __asm__ volatile("cli"); /* Disable interrupts */
+    system_ticks = 0;
+    __asm__ volatile("sti"); /* Re-enable interrupts */
+    terminal_writeline("System timer reset to 0");
+}
+
+/* Set timer callback function */
+void timer_set_callback(timer_callback_t callback) {
+    timer_callback = callback;
+    if (callback) {
+        terminal_writeline("Timer callback function registered");
+    }
+}
+
+/* Clear timer callback function */
+void timer_clear_callback(void) {
+    timer_callback = NULL;
+    terminal_writeline("Timer callback function cleared");
+}
+
+/* Timer tick handler - called from interrupt handler */
+void timer_tick(void) {
+    /* Increment system tick counter */
+    system_ticks++;
+    
+    /* Call user callback if registered */
+    if (timer_callback) {
+        timer_callback();
+    }
+}
+
+/* Display timer information */
+void timer_display_info(void) {
+    terminal_writeline("========== Timer Information ==========");
+    
+    char line[64];
+    char num_str[16];
+    
+    /* Current frequency */
+    strcpy(line, "Frequency: ");
+    int_to_string(timer_frequency, num_str);
+    strcat(line, num_str);
+    strcat(line, " Hz");
+    terminal_writeline(line);
+    
+    /* Current ticks */
+    strcpy(line, "System ticks: ");
+    int_to_string(system_ticks, num_str);
+    strcat(line, num_str);
+    terminal_writeline(line);
+    
+    /* Uptime in seconds */
+    strcpy(line, "Uptime: ");
+    int_to_string(timer_get_seconds(), num_str);
+    strcat(line, num_str);
+    strcat(line, " seconds");
+    terminal_writeline(line);
+    
+    /* Callback status */
+    strcpy(line, "Callback: ");
+    strcat(line, timer_callback ? "Registered" : "None");
+    terminal_writeline(line);
+    
+    terminal_writeline("======================================");
+}


### PR DESCRIPTION
This pull request introduces a Programmable Interval Timer (PIT) subsystem to the kernel, enabling timer-based functionality such as system ticks, timer callbacks, and periodic interrupts. The changes include adding the necessary source files, headers, and functionality to integrate the PIT into the kernel's initialization and interrupt handling processes.

### Timer Subsystem Implementation:
* Added a new `pit.c` file to implement the PIT subsystem, including functions for initialization, frequency setting, tick handling, and timer callbacks. (`kernel/src/timer/pit.c`)
* Added a corresponding header file `pit.h` defining PIT constants, function prototypes, and timer-related variables. (`kernel/include/timer/pit.h`)

### Kernel Integration:
* Updated `kernel_main.c` to initialize the PIT during kernel startup, set the timer frequency to 100Hz, and register a heartbeat callback. Added functions to display timer information and periodic heartbeat messages. (`kernel/kernel_main.c`) [[1]](diffhunk://#diff-c60f4eed8d36a97b7fb4f7b4f1732d9dae6c47e249a987b5b52303e6910b5ebaR3) [[2]](diffhunk://#diff-c60f4eed8d36a97b7fb4f7b4f1732d9dae6c47e249a987b5b52303e6910b5ebaR51-R99) [[3]](diffhunk://#diff-c60f4eed8d36a97b7fb4f7b4f1732d9dae6c47e249a987b5b52303e6910b5ebaR127-R135) [[4]](diffhunk://#diff-c60f4eed8d36a97b7fb4f7b4f1732d9dae6c47e249a987b5b52303e6910b5ebaR164-L117)
* Modified the interrupt handler to call `timer_tick()` on each timer interrupt, updating the system tick count and triggering any registered callbacks. (`kernel/src/interrupts/interrupt_handlers.c`) [[1]](diffhunk://#diff-8f489d2468b875c4911b54e62365ef3752a13b4cea8d75f3e3c6a91945810d01R6) [[2]](diffhunk://#diff-8f489d2468b875c4911b54e62365ef3752a13b4cea8d75f3e3c6a91945810d01R22-R24)

### Build System Updates:
* Updated the `Makefile` to include the new `pit.c` source file and its corresponding object file in the kernel build process. (`Makefile`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L46-R47) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L68-R70) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R182-R185)

### Bootloader Adjustment:
* Increased the `KERNEL_SECTORS` constant in the bootloader to accommodate the additional size of the kernel after adding the PIT subsystem. (`boot/stage2.asm`)