### PR TITLE
Feature/syscall and interrupt exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ KERNEL_C_SOURCES = $(KERNEL_MAIN) \
 # Assembly source files
 KERNEL_ASM_SOURCES = $(KERNEL_ENTRY) \
                      $(KERNEL_SRC_DIR)/interrupts/interrupt_handlers.asm \
-                     $(KERNEL_SRC_DIR)/process/context_switch.asm
+                     $(KERNEL_SRC_DIR)/process/context_switch.asm \
+                     $(KERNEL_SRC_DIR)/syscalls/syscall_interrupt.asm
 
 # Object files
 KERNEL_ENTRY_OBJ = $(BUILD_DIR)/kernel_entry.o
@@ -70,7 +71,8 @@ KERNEL_C_OBJS = $(BUILD_DIR)/kernel_main.o \
                 $(BUILD_DIR)/pit.o
 
 KERNEL_ASM_OBJS = $(BUILD_DIR)/interrupt_handlers_asm.o \
-                  $(BUILD_DIR)/context_switch.o
+                  $(BUILD_DIR)/context_switch.o \
+                  $(BUILD_DIR)/syscall_interrupt.o
 
 .PHONY: all clean run debug stage1 stage2 kernel hdd structure help
 
@@ -185,6 +187,10 @@ $(BUILD_DIR)/pit.o: $(KERNEL_SRC_DIR)/timer/pit.c | $(BUILD_DIR)
 
 # Build context_switch.asm
 $(BUILD_DIR)/context_switch.o: $(KERNEL_SRC_DIR)/process/context_switch.asm | $(BUILD_DIR)
+	$(NASM) $(NASMFLAGS) -o $@ $<
+
+# Build syscall_interrupt.asm
+$(BUILD_DIR)/syscall_interrupt.o: $(KERNEL_SRC_DIR)/syscalls/syscall_interrupt.asm | $(BUILD_DIR)
 	$(NASM) $(NASMFLAGS) -o $@ $<
 
 # Run the OS in QEMU

--- a/boot/stage2.asm
+++ b/boot/stage2.asm
@@ -9,7 +9,7 @@
 
 ; === Constants ===
 KERNEL_OFFSET equ 0x10000       ; Load kernel at 64KB (safe location)
-KERNEL_SECTORS equ 90           ; Max sectors for kernel (90 * 512 = 46080 bytes)
+KERNEL_SECTORS equ 98           ; Max sectors for kernel (98 * 512 = 50176 bytes)
 KERNEL_START_SECTOR equ 11      ; Kernel starts at sector 11
 
 ; GDT segment selectors

--- a/kernel/include/common/utils.h
+++ b/kernel/include/common/utils.h
@@ -6,6 +6,7 @@
 /* String utility functions */
 size_t strlen(const char* str);
 void int_to_string(int value, char* str);
+void int_to_hex_string(uint32_t value, char* str);
 void int_to_hex(int value, char* str);
 int strcmp(const char* str1, const char* str2);
 void strcpy(char* dest, const char* src);

--- a/kernel/include/interrupts/interrupts.h
+++ b/kernel/include/interrupts/interrupts.h
@@ -38,4 +38,36 @@ void pic_display_status(void);
 void irq_handler_timer(void);
 void irq_handler_keyboard(void);
 
+/* Exception handlers */
+void exception_handler_0(void);   /* Division by zero */
+void exception_handler_1(void);   /* Debug */
+void exception_handler_2(void);   /* Non-maskable interrupt */
+void exception_handler_3(void);   /* Breakpoint */
+void exception_handler_4(void);   /* Overflow */
+void exception_handler_5(void);   /* Bound range exceeded */
+void exception_handler_6(void);   /* Invalid opcode */
+void exception_handler_7(void);   /* Device not available */
+void exception_handler_8(void);   /* Double fault */
+void exception_handler_9(void);   /* Coprocessor segment overrun */
+void exception_handler_10(void);  /* Invalid TSS */
+void exception_handler_11(void);  /* Segment not present */
+void exception_handler_12(void);  /* Stack-segment fault */
+void exception_handler_13(void);  /* General protection fault */
+void exception_handler_14(void);  /* Page fault */
+void exception_handler_15(void);  /* Reserved */
+void exception_handler_16(void);  /* x87 FPU floating-point error */
+void exception_handler_17(void);  /* Alignment check */
+void exception_handler_18(void);  /* Machine check */
+void exception_handler_19(void);  /* SIMD floating-point exception */
+
+/* C interrupt handlers */
+void c_irq_handler_timer(void);
+void c_irq_handler_keyboard(void);
+void c_exception_handler(void* ctx);
+
+/* Interrupt statistics and debugging */
+void get_interrupt_statistics(uint32_t* timer_count, uint32_t* keyboard_count, uint32_t* spurious_count);
+void reset_interrupt_statistics(void);
+void display_interrupt_statistics(void);
+
 #endif /* INTERRUPTS_H */

--- a/kernel/src/common/utils.c
+++ b/kernel/src/common/utils.c
@@ -51,6 +51,42 @@ void int_to_string(int value, char* str) {
     }
 }
 
+/* Convert integer to hexadecimal string */
+void int_to_hex_string(uint32_t value, char* str) {
+    int i = 0;
+    
+    /* Handle 0 explicitly */
+    if (value == 0) {
+        str[i++] = '0';
+        str[i] = '\0';
+        return;
+    }
+    
+    /* Process individual hex digits */
+    while (value != 0) {
+        int remainder = value % 16;
+        if (remainder < 10) {
+            str[i++] = remainder + '0';
+        } else {
+            str[i++] = remainder - 10 + 'A';
+        }
+        value = value / 16;
+    }
+    
+    str[i] = '\0'; /* Null-terminate string */
+    
+    /* Reverse the string */
+    int start = 0;
+    int end = i - 1;
+    while (start < end) {
+        char temp = str[start];
+        str[start] = str[end];
+        str[end] = temp;
+        start++;
+        end--;
+    }
+}
+
 /* Compare two strings */
 int strcmp(const char* str1, const char* str2) {
     while (*str1 && (*str1 == *str2)) {

--- a/kernel/src/interrupts/idt.c
+++ b/kernel/src/interrupts/idt.c
@@ -40,7 +40,29 @@ void interrupts_initialize(void) {
     /* Clear IDT */
     memset(&idt, 0, sizeof(idt));
     
-    /* Set hardware interrupt handlers */
+    /* Set CPU exception handlers (0-31) */
+    idt_set_gate(0, (uint32_t)exception_handler_0, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Division by zero */
+    idt_set_gate(1, (uint32_t)exception_handler_1, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Debug */
+    idt_set_gate(2, (uint32_t)exception_handler_2, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Non-maskable interrupt */
+    idt_set_gate(3, (uint32_t)exception_handler_3, 0x08, IDT_TYPE_TRAP_GATE);        /* Breakpoint (trap gate) */
+    idt_set_gate(4, (uint32_t)exception_handler_4, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Overflow */
+    idt_set_gate(5, (uint32_t)exception_handler_5, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Bound range exceeded */
+    idt_set_gate(6, (uint32_t)exception_handler_6, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Invalid opcode */
+    idt_set_gate(7, (uint32_t)exception_handler_7, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Device not available */
+    idt_set_gate(8, (uint32_t)exception_handler_8, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Double fault */
+    idt_set_gate(9, (uint32_t)exception_handler_9, 0x08, IDT_TYPE_INTERRUPT_GATE);   /* Coprocessor segment overrun */
+    idt_set_gate(10, (uint32_t)exception_handler_10, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Invalid TSS */
+    idt_set_gate(11, (uint32_t)exception_handler_11, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Segment not present */
+    idt_set_gate(12, (uint32_t)exception_handler_12, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Stack-segment fault */
+    idt_set_gate(13, (uint32_t)exception_handler_13, 0x08, IDT_TYPE_INTERRUPT_GATE); /* General protection fault */
+    idt_set_gate(14, (uint32_t)exception_handler_14, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Page fault */
+    idt_set_gate(15, (uint32_t)exception_handler_15, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Reserved */
+    idt_set_gate(16, (uint32_t)exception_handler_16, 0x08, IDT_TYPE_INTERRUPT_GATE); /* x87 FPU floating-point error */
+    idt_set_gate(17, (uint32_t)exception_handler_17, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Alignment check */
+    idt_set_gate(18, (uint32_t)exception_handler_18, 0x08, IDT_TYPE_INTERRUPT_GATE); /* Machine check */
+    idt_set_gate(19, (uint32_t)exception_handler_19, 0x08, IDT_TYPE_INTERRUPT_GATE); /* SIMD floating-point exception */
+    
+    /* Set hardware interrupt handlers (32+) */
     idt_set_gate(32, (uint32_t)irq_handler_timer, 0x08, IDT_TYPE_INTERRUPT_GATE);
     idt_set_gate(33, (uint32_t)irq_handler_keyboard, 0x08, IDT_TYPE_INTERRUPT_GATE);
     
@@ -51,6 +73,7 @@ void interrupts_initialize(void) {
     pic_initialize();
     
     terminal_writeline("IDT initialized successfully!");
+    terminal_writeline("Exception handlers (0-14) and IRQ handlers (32-33) installed.");
 }
 
 /* PIC ports */

--- a/kernel/src/interrupts/interrupt_handlers.asm
+++ b/kernel/src/interrupts/interrupt_handlers.asm
@@ -1,61 +1,159 @@
 [BITS 32]
 
-; 외부 C 핸들러 함수 선언
+; External C handler function declarations
 extern c_irq_handler_timer
 extern c_irq_handler_keyboard
+extern c_exception_handler
 
-; IRQ 핸들러 전역 선언
+; IRQ handler global declarations
 global irq_handler_timer
 global irq_handler_keyboard
+global exception_handler_common
 
-; 타이머 IRQ 핸들러 (IRQ0)
+; Exception handlers (0-31)
+global exception_handler_0   ; Division by zero
+global exception_handler_1   ; Debug
+global exception_handler_2   ; Non-maskable interrupt
+global exception_handler_3   ; Breakpoint
+global exception_handler_4   ; Overflow
+global exception_handler_5   ; Bound range exceeded
+global exception_handler_6   ; Invalid opcode
+global exception_handler_7   ; Device not available
+global exception_handler_8   ; Double fault
+global exception_handler_9   ; Coprocessor segment overrun
+global exception_handler_10  ; Invalid TSS
+global exception_handler_11  ; Segment not present
+global exception_handler_12  ; Stack-segment fault
+global exception_handler_13  ; General protection fault
+global exception_handler_14  ; Page fault
+global exception_handler_15  ; Reserved
+global exception_handler_16  ; x87 FPU floating-point error
+global exception_handler_17  ; Alignment check
+global exception_handler_18  ; Machine check
+global exception_handler_19  ; SIMD floating-point exception
+
+; Common interrupt handler macro for code reuse
+%macro IRQ_HANDLER_COMMON 1
+    ; NOTE: CLI is not needed - interrupts are automatically disabled
+    ; when entering an interrupt handler via interrupt gate
+    pusha              ; Save all general-purpose registers
+    
+    ; Save segment registers
+    mov ax, ds
+    push eax
+    mov ax, es  
+    push eax
+    mov ax, fs
+    push eax
+    mov ax, gs
+    push eax
+    
+    ; Load kernel data segment
+    mov ax, 0x10       ; Kernel data segment selector
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    
+    ; Push IRQ number as parameter
+    push %1
+    call %1            ; Call the specific C handler
+    add esp, 4         ; Clean up stack (remove parameter)
+    
+    ; Restore segment registers
+    pop eax
+    mov gs, ax
+    pop eax
+    mov fs, ax
+    pop eax
+    mov es, ax
+    pop eax
+    mov ds, ax
+    
+    popa               ; Restore general-purpose registers
+    iret               ; Return from interrupt (automatically enables interrupts)
+%endmacro
+
+; Exception handler macro for CPU exceptions
+%macro EXCEPTION_HANDLER 2
+exception_handler_%1:
+    ; Some exceptions push error code, others don't
+    %if %2 == 0
+        push 0         ; Push dummy error code for exceptions that don't have one
+    %endif
+    push %1            ; Push exception number
+    jmp exception_handler_common
+%endmacro
+
+; Timer IRQ handler (IRQ0 -> INT 32)
 irq_handler_timer:
-    cli                ; 인터럽트 비활성화
-    pusha              ; 모든 범용 레지스터를 스택에 저장
-    
-    mov ax, ds         ; 데이터 세그먼트 저장
-    push eax
-    
-    mov ax, 0x10       ; 커널 데이터 세그먼트 로드
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-    
-    call c_irq_handler_timer   ; C 핸들러 함수 호출
-    
-    pop eax            ; 데이터 세그먼트 복원
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-    
-    popa               ; 레지스터 복원
-    sti                ; 인터럽트 활성화
-    iret               ; 인터럽트에서 복귀
+    IRQ_HANDLER_COMMON c_irq_handler_timer
 
-; 키보드 IRQ 핸들러 (IRQ1)
+; Keyboard IRQ handler (IRQ1 -> INT 33)  
 irq_handler_keyboard:
-    cli                ; 인터럽트 비활성화
-    pusha              ; 모든 범용 레지스터를 스택에 저장
+    IRQ_HANDLER_COMMON c_irq_handler_keyboard
+
+; Exception handlers
+EXCEPTION_HANDLER 0, 0   ; Division by zero
+EXCEPTION_HANDLER 1, 0   ; Debug
+EXCEPTION_HANDLER 2, 0   ; Non-maskable interrupt
+EXCEPTION_HANDLER 3, 0   ; Breakpoint
+EXCEPTION_HANDLER 4, 0   ; Overflow
+EXCEPTION_HANDLER 5, 0   ; Bound range exceeded
+EXCEPTION_HANDLER 6, 0   ; Invalid opcode
+EXCEPTION_HANDLER 7, 0   ; Device not available
+EXCEPTION_HANDLER 8, 1   ; Double fault (has error code)
+EXCEPTION_HANDLER 9, 0   ; Coprocessor segment overrun
+EXCEPTION_HANDLER 10, 1  ; Invalid TSS (has error code)
+EXCEPTION_HANDLER 11, 1  ; Segment not present (has error code)
+EXCEPTION_HANDLER 12, 1  ; Stack-segment fault (has error code)
+EXCEPTION_HANDLER 13, 1  ; General protection fault (has error code)
+EXCEPTION_HANDLER 14, 1  ; Page fault (has error code)
+EXCEPTION_HANDLER 15, 0  ; Reserved
+EXCEPTION_HANDLER 16, 0  ; x87 FPU floating-point error
+EXCEPTION_HANDLER 17, 1  ; Alignment check (has error code)
+EXCEPTION_HANDLER 18, 0  ; Machine check
+EXCEPTION_HANDLER 19, 0  ; SIMD floating-point exception
+
+; Common exception handler
+exception_handler_common:
+    pusha              ; Save all general-purpose registers
     
-    mov ax, ds         ; 데이터 세그먼트 저장
+    ; Save segment registers
+    mov ax, ds
+    push eax
+    mov ax, es
+    push eax
+    mov ax, fs
+    push eax
+    mov ax, gs
     push eax
     
-    mov ax, 0x10       ; 커널 데이터 세그먼트 로드
+    ; Load kernel data segment
+    mov ax, 0x10
     mov ds, ax
     mov es, ax
     mov fs, ax
     mov gs, ax
     
-    call c_irq_handler_keyboard   ; C 핸들러 함수 호출
+    ; Call C exception handler
+    ; Stack layout: [gs][fs][es][ds][popa_registers][exception_num][error_code][eip][cs][eflags]
+    ; Pass pointer to the exception context as parameter
+    mov eax, esp       ; ESP points to the context structure
+    push eax           ; Pass context pointer as parameter
+    call c_exception_handler
+    add esp, 4         ; Clean up parameter
     
-    pop eax            ; 데이터 세그먼트 복원
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
+    ; Restore segment registers
+    pop eax
     mov gs, ax
+    pop eax
+    mov fs, ax
+    pop eax
+    mov es, ax
+    pop eax
+    mov ds, ax
     
-    popa               ; 레지스터 복원
-    sti                ; 인터럽트 활성화
-    iret               ; 인터럽트에서 복귀
+    popa               ; Restore general-purpose registers
+    add esp, 8         ; Remove exception number and error code from stack
+    iret               ; Return from interrupt

--- a/kernel/src/interrupts/interrupt_handlers.c
+++ b/kernel/src/interrupts/interrupt_handlers.c
@@ -4,26 +4,97 @@
 #include "../../include/keyboard/keyboard.h"
 #include "../../include/process/process.h"
 #include "../../include/timer/pit.h"
+#include "../../include/terminal/terminal.h"
+
+/* Interrupt statistics for debugging */
+static uint32_t timer_interrupt_count = 0;
+static uint32_t keyboard_interrupt_count = 0;
+static uint32_t spurious_interrupt_count = 0;
+
+/* Exception names for debugging */
+static const char* exception_names[] = {
+    "Division by zero",
+    "Debug",
+    "Non-maskable interrupt", 
+    "Breakpoint",
+    "Overflow",
+    "Bound range exceeded",
+    "Invalid opcode",
+    "Device not available",
+    "Double fault",
+    "Coprocessor segment overrun",
+    "Invalid TSS",
+    "Segment not present",
+    "Stack-segment fault",
+    "General protection fault",
+    "Page fault",
+    "Reserved",
+    "x87 FPU floating-point error",
+    "Alignment check",
+    "Machine check",
+    "SIMD floating-point exception"
+};
+
+/* CPU exception context structure */
+typedef struct {
+    uint32_t gs, fs, es, ds;                    /* Segment registers */
+    uint32_t edi, esi, ebp, esp, ebx, edx, ecx, eax; /* General registers (pusha order) */
+    uint32_t exception_num, error_code;         /* Exception info */
+    uint32_t eip, cs, eflags;                   /* CPU pushed registers */
+    uint32_t user_esp, user_ss;                 /* Only if privilege change occurred */
+} __attribute__((packed)) exception_context_t;
 
 /* Helper function to send EOI signal to PIC */
-static inline void send_eoi(uint32_t int_no) {
-    /* For IRQs 0-7 (interrupts 32-39), send EOI to master PIC only */
+static inline void send_eoi(uint32_t irq_num) {
+    /* Validate IRQ number */
+    if (irq_num < 32 || irq_num > 47) {
+        return; /* Invalid IRQ number */
+    }
+    
     /* For IRQs 8-15 (interrupts 40-47), send EOI to both slave and master PIC */
-    if (int_no >= 40) {
-        /* Slave PIC */
+    if (irq_num >= 40) {
+        /* Send EOI to slave PIC */
         __asm__ volatile("outb %0, %1" : : "a"((uint8_t)0x20), "Nd"((uint16_t)0xA0));
     }
-    /* Master PIC - always send for any IRQ */
+    /* Send EOI to master PIC - always required for any IRQ */
     __asm__ volatile("outb %0, %1" : : "a"((uint8_t)0x20), "Nd"((uint16_t)0x20));
+}
+
+/* Check for spurious interrupts */
+static bool is_spurious_irq(uint32_t irq_num) {
+    uint8_t irr;
+    
+    if (irq_num == 39) { /* Spurious IRQ 7 on master PIC */
+        /* Read IRR (In-Service Register) of master PIC */
+        __asm__ volatile("outb %0, %1" : : "a"((uint8_t)0x0B), "Nd"((uint16_t)0x20));
+        __asm__ volatile("inb %1, %0" : "=a"(irr) : "Nd"((uint16_t)0x20));
+        return !(irr & 0x80); /* Check if IRQ 7 bit is set */
+    } else if (irq_num == 47) { /* Spurious IRQ 15 on slave PIC */
+        /* Read IRR of slave PIC */
+        __asm__ volatile("outb %0, %1" : : "a"((uint8_t)0x0B), "Nd"((uint16_t)0xA0));
+        __asm__ volatile("inb %1, %0" : "=a"(irr) : "Nd"((uint16_t)0xA0));
+        if (!(irr & 0x80)) { /* IRQ 15 not set, it's spurious */
+            /* Still need to send EOI to master PIC for spurious slave interrupts */
+            __asm__ volatile("outb %0, %1" : : "a"((uint8_t)0x20), "Nd"((uint16_t)0x20));
+            return true;
+        }
+    }
+    return false;
 }
 
 /* Timer interrupt handler */
 void c_irq_handler_timer(void) {
-    /* Update timer tick count */
-    timer_tick();
+    /* Check for spurious interrupt */
+    if (is_spurious_irq(32)) {
+        spurious_interrupt_count++;
+        return;
+    }
     
-    /* Handle process scheduling on timer tick */
-    scheduler_tick();
+    /* Increment statistics */
+    timer_interrupt_count++;
+    
+    /* Update timer tick count - timer_tick() already calls scheduler_tick() */
+    timer_tick();
     
     /* Send EOI to PIC */
     send_eoi(32);
@@ -31,9 +102,146 @@ void c_irq_handler_timer(void) {
 
 /* Keyboard interrupt handler */
 void c_irq_handler_keyboard(void) {
+    /* Check for spurious interrupt */
+    if (is_spurious_irq(33)) {
+        spurious_interrupt_count++;
+        return;
+    }
+    
+    /* Increment statistics */
+    keyboard_interrupt_count++;
+    
     /* Call keyboard handler function */
     keyboard_handler();
     
     /* Send EOI to PIC */
     send_eoi(33);
+}
+
+/* Exception handler */
+void c_exception_handler(void* context) {
+    exception_context_t* ctx = (exception_context_t*)context;
+    /* Disable interrupts during exception handling */
+    __asm__ volatile("cli");
+    
+    /* Clear screen and display exception information */
+    terminal_clear();
+    terminal_setcolor(vga_entry_color(VGA_COLOR_WHITE, VGA_COLOR_RED));
+    
+    terminal_writestring("=== KERNEL PANIC: CPU EXCEPTION ===\n");
+    
+    /* Display exception name */
+    if (ctx->exception_num < 20) {
+        terminal_writestring("Exception: ");
+        terminal_writestring(exception_names[ctx->exception_num]);
+    } else {
+        terminal_writestring("Unknown Exception");
+    }
+    terminal_writestring(" (");
+    
+    /* Display exception number */
+    char num_str[16];
+    int_to_string(ctx->exception_num, num_str);
+    terminal_writestring(num_str);
+    terminal_writestring(")\n");
+    
+    /* Display error code if present */
+    if (ctx->error_code != 0) {
+        terminal_writestring("Error Code: 0x");
+        int_to_hex(ctx->error_code, num_str);
+        terminal_writestring(num_str);
+        terminal_writestring("\n");
+    }
+    
+    /* Display register values */
+    terminal_writestring("\nRegisters:\n");
+    terminal_writestring("EAX=0x"); int_to_hex(ctx->eax, num_str); terminal_writestring(num_str);
+    terminal_writestring(" EBX=0x"); int_to_hex(ctx->ebx, num_str); terminal_writestring(num_str);
+    terminal_writestring(" ECX=0x"); int_to_hex(ctx->ecx, num_str); terminal_writestring(num_str);
+    terminal_writestring(" EDX=0x"); int_to_hex(ctx->edx, num_str); terminal_writeline(num_str);
+    
+    terminal_writestring("ESI=0x"); int_to_hex(ctx->esi, num_str); terminal_writestring(num_str);
+    terminal_writestring(" EDI=0x"); int_to_hex(ctx->edi, num_str); terminal_writestring(num_str);
+    terminal_writestring(" EBP=0x"); int_to_hex(ctx->ebp, num_str); terminal_writestring(num_str);
+    terminal_writestring(" ESP=0x"); int_to_hex(ctx->esp, num_str); terminal_writeline(num_str);
+    
+    terminal_writestring("EIP=0x"); int_to_hex(ctx->eip, num_str); terminal_writestring(num_str);
+    terminal_writestring(" CS=0x"); int_to_hex(ctx->cs, num_str); terminal_writestring(num_str);
+    terminal_writestring(" EFLAGS=0x"); int_to_hex(ctx->eflags, num_str); terminal_writeline(num_str);
+    
+    terminal_writestring("DS=0x"); int_to_hex(ctx->ds, num_str); terminal_writestring(num_str);
+    terminal_writestring(" ES=0x"); int_to_hex(ctx->es, num_str); terminal_writestring(num_str);
+    terminal_writestring(" FS=0x"); int_to_hex(ctx->fs, num_str); terminal_writestring(num_str);
+    terminal_writestring(" GS=0x"); int_to_hex(ctx->gs, num_str); terminal_writeline(num_str);
+    
+    /* Display additional info for specific exceptions */
+    if (ctx->exception_num == 14) { /* Page fault */
+        uint32_t fault_addr;
+        __asm__ volatile("mov %%cr2, %0" : "=r"(fault_addr));
+        terminal_writestring("\nPage Fault Address: 0x");
+        int_to_hex(fault_addr, num_str);
+        terminal_writeline(num_str);
+        
+        terminal_writestring("Fault Type: ");
+        if (ctx->error_code & 0x1) terminal_writestring("Protection violation ");
+        else terminal_writestring("Page not present ");
+        if (ctx->error_code & 0x2) terminal_writestring("(Write) ");
+        else terminal_writestring("(Read) ");
+        if (ctx->error_code & 0x4) terminal_writestring("(User mode)");
+        else terminal_writestring("(Kernel mode)");
+        terminal_writeline("");
+    }
+    
+    /* Display current process information if available */
+    process_t* current = get_current_process();
+    if (current) {
+        terminal_writestring("\nCurrent Process: PID ");
+        int_to_string(current->pid, num_str);
+        terminal_writeline(num_str);
+    }
+    
+    terminal_writeline("\nSystem halted. Please reboot.");
+    
+    /* Halt the system */
+    while (1) {
+        __asm__ volatile("cli; hlt");
+    }
+}
+
+/* Get interrupt statistics for debugging */
+void get_interrupt_statistics(uint32_t* timer_count, uint32_t* keyboard_count, uint32_t* spurious_count) {
+    if (timer_count) *timer_count = timer_interrupt_count;
+    if (keyboard_count) *keyboard_count = keyboard_interrupt_count;
+    if (spurious_count) *spurious_count = spurious_interrupt_count;
+}
+
+/* Reset interrupt statistics */
+void reset_interrupt_statistics(void) {
+    timer_interrupt_count = 0;
+    keyboard_interrupt_count = 0;
+    spurious_interrupt_count = 0;
+}
+
+/* Display interrupt statistics for debugging */
+void display_interrupt_statistics(void) {
+    uint32_t timer_count, keyboard_count, spurious_count;
+    char count_str[16];
+    
+    get_interrupt_statistics(&timer_count, &keyboard_count, &spurious_count);
+    
+    terminal_writeline("=== Interrupt Statistics ===");
+    
+    terminal_writestring("Timer interrupts: ");
+    int_to_string(timer_count, count_str);
+    terminal_writeline(count_str);
+    
+    terminal_writestring("Keyboard interrupts: ");
+    int_to_string(keyboard_count, count_str);
+    terminal_writeline(count_str);
+    
+    terminal_writestring("Spurious interrupts: ");
+    int_to_string(spurious_count, count_str);
+    terminal_writeline(count_str);
+    
+    terminal_writeline("============================");
 }

--- a/kernel/src/syscalls/syscall_interrupt.asm
+++ b/kernel/src/syscalls/syscall_interrupt.asm
@@ -1,0 +1,52 @@
+[BITS 32]
+
+; System call interrupt handler
+global syscall_interrupt_handler
+extern syscall_handler
+
+; System call interrupt handler (INT 0x80)
+syscall_interrupt_handler:
+    ; Disable interrupts
+    cli
+    
+    ; Save all registers
+    pusha
+    
+    ; Save segment registers
+    push ds
+    push es
+    push fs
+    push gs
+    
+    ; Load kernel data segment
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    
+    ; Push arguments for syscall_handler
+    ; System call convention: EAX = syscall number, EBX = arg1, ECX = arg2, EDX = arg3
+    push edx    ; arg3
+    push ecx    ; arg2
+    push ebx    ; arg1
+    push eax    ; syscall_num
+    
+    ; Call C handler
+    call syscall_handler
+    
+    ; Clean up stack (4 arguments)
+    add esp, 16
+    
+    ; Restore segment registers
+    pop gs
+    pop fs
+    pop es
+    pop ds
+    
+    ; Restore all registers
+    popa
+    
+    ; Enable interrupts and return
+    sti
+    iret

--- a/kernel/src/syscalls/syscalls.c
+++ b/kernel/src/syscalls/syscalls.c
@@ -134,7 +134,11 @@ int sys_exec(const char* path, char* const argv[]) {
 
 /* Setup system call interrupt (INT 0x80) */
 void setup_syscall_interrupt(void) {
-    /* This would register the syscall handler with interrupt 0x80 */
-    /* Implementation depends on your interrupt system */
+    /* Register INT 0x80 handler in IDT */
+    extern void syscall_interrupt_handler(void);
+    
+    /* Set IDT gate for system call interrupt */
+    idt_set_gate(0x80, (uint32_t)syscall_interrupt_handler, 0x08, IDT_TYPE_INTERRUPT_GATE);
+    
     terminal_writeline("System call interrupt (INT 0x80) registered");
 }

--- a/kernel/src/timer/pit.c
+++ b/kernel/src/timer/pit.c
@@ -1,6 +1,7 @@
 #include "../../include/timer/pit.h"
 #include "../../include/terminal/terminal.h"
 #include "../../include/common/utils.h"
+#include "../../include/process/process.h"
 
 /* Global timer variables */
 volatile uint32_t system_ticks = 0;         /* Number of timer ticks since boot */
@@ -144,6 +145,9 @@ void timer_clear_callback(void) {
 void timer_tick(void) {
     /* Increment system tick counter */
     system_ticks++;
+    
+    /* Call scheduler tick for multitasking */
+    scheduler_tick();
     
     /* Call user callback if registered */
     if (timer_callback) {


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the kernel's interrupt handling system, including support for CPU exceptions, enhanced debugging utilities, and expanded functionality for interrupt statistics. Key changes include the addition of exception handlers, updates to the interrupt descriptor table (IDT), new utility functions, and improved debugging capabilities.

### Interrupt Handling Enhancements:
* Added support for CPU exceptions (0-19) with individual handlers and a common handler macro for reuse in `kernel/src/interrupts/interrupt_handlers.asm`.
* Updated the IDT initialization in `kernel/src/interrupts/idt.c` to register exception handlers and provide debugging output. [[1]](diffhunk://#diff-9b87eeed44926a74a22120187f4f99164e0464b58ade13790de9e90cd24dd54fL43-R65) [[2]](diffhunk://#diff-9b87eeed44926a74a22120187f4f99164e0464b58ade13790de9e90cd24dd54fR76)
* Introduced a `c_exception_handler` in `kernel/src/interrupts/interrupt_handlers.c` to handle CPU exceptions, display detailed debugging information, and halt the system on critical errors.

### Debugging Utilities:
* Added functions in `kernel/src/interrupts/interrupt_handlers.c` to track and display interrupt statistics, including timer, keyboard, and spurious interrupts.
* Enhanced exception debugging by displaying exception names, register values, and additional context such as page fault details.

### Utility and Common Functions:
* Added `int_to_hex_string` in `kernel/src/common/utils.c` for converting integers to hexadecimal strings, improving debugging output. [[1]](diffhunk://#diff-500b14ea84a56e056b62751d547b0a191511111835c1508a8d118080ca511515R54-R89) [[2]](diffhunk://#diff-a2688e5f5501f539837d387d58b0572ff188ca0620c406a733a4cad16195dacbR9)

### Build System Updates:
* Updated the `Makefile` to include the new `syscall_interrupt.asm` file in the build process. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L52-R53) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L73-R75) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R192-R195)

### Bootloader Adjustments:
* Increased the `KERNEL_SECTORS` constant in `boot/stage2.asm` to accommodate the larger kernel size.