### PR TITLE
Debug/context switch after process return

### DIFF
--- a/boot/stage2.asm
+++ b/boot/stage2.asm
@@ -9,7 +9,7 @@
 
 ; === Constants ===
 KERNEL_OFFSET equ 0x10000       ; Load kernel at 64KB (safe location)
-KERNEL_SECTORS equ 89           ; Max sectors for kernel (89 * 512 = 45408 bytes)
+KERNEL_SECTORS equ 93           ; Max sectors for kernel (93 * 512 = 47616 bytes)
 KERNEL_START_SECTOR equ 11      ; Kernel starts at sector 11
 
 ; GDT segment selectors

--- a/kernel/include/process/process.h
+++ b/kernel/include/process/process.h
@@ -86,6 +86,7 @@ void process_init(void);
 process_t* process_create(const char* name, void (*entry_point)(void), process_priority_t priority);
 process_t* process_fork(process_t* parent);
 void process_terminate(process_t* process);
+void process_set_zombie(process_t* process);
 int process_kill(process_t* process, int signal);
 int process_wait(process_t* parent, pid_t child_pid);
 int process_exec(process_t* process, const char* path, char* const argv[]);

--- a/kernel/src/syscalls/syscalls.c
+++ b/kernel/src/syscalls/syscalls.c
@@ -62,6 +62,10 @@ void sys_exit(int exit_code) {
         strcat(msg, code_str);
         terminal_writeline(msg);
         
+        /* Set exit code before terminating */
+        current->exit_code = exit_code;
+        
+        /* Terminate the process (this will call scheduler_switch_process internally) */
         process_terminate(current);
         scheduler_switch_process();
     }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the kernel's process management system, including improved process lifecycle handling, better debugging output, and support for automatic cleanup of processes that return without explicitly exiting. The changes also include updates to kernel constants and minor adjustments to syscall behavior.

### Process lifecycle improvements:
* Added a `process_wrapper` function to ensure automatic cleanup for processes that return without calling `exit`. This includes logging the process details and invoking `sys_exit` with a default status. (`kernel/src/process/process.c`, [[1]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R29-R55) [[2]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83L121-R172) [[3]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R763-R772)
* Introduced a `process_set_zombie` function to transition terminated processes into a zombie state, allowing the parent process to collect their exit status. (`kernel/include/process/process.h`, [[1]](diffhunk://#diff-a7924880b8708c637050fb48373766a19a709e45d1608734933692f68e805543R89); `kernel/src/process/process.c`, [[2]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R455-R478)
* Enhanced `process_terminate` to log detailed information about the terminated process, notify the parent process, handle orphaned child processes, and provide a summary of remaining processes for debugging. (`kernel/src/process/process.c`, [kernel/src/process/process.cL170-R290](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83L170-R290))

### Debugging and logging enhancements:
* Added detailed logging for process creation, including the PID of the newly created processes, and the total number of processes in the scheduler. (`kernel/src/process/process.c`, [[1]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R815-R818) [[2]](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R828-R844)
* Improved logging in `scheduler_switch_process` to handle cases where the old process is null. (`kernel/src/process/process.c`, [kernel/src/process/process.cR583-R586](diffhunk://#diff-067abac557eb3a65a72996a2c3253eefd1f51522ee0ec9ec6bcb35290494ee83R583-R586))

### Kernel constants update:
* Increased the `KERNEL_SECTORS` constant from 89 to 93 to accommodate a larger kernel size. (`boot/stage2.asm`, [boot/stage2.asmL12-R12](diffhunk://#diff-1286f221d51f318a49285fa8deaba8c4540f0c0dd25124e90b324df55e7a68e3L12-R12))

### Syscall updates:
* Modified `sys_exit` to set the process exit code before terminating the process, ensuring proper cleanup and state transition. (`kernel/src/syscalls/syscalls.c`, [kernel/src/syscalls/syscalls.cR65-R68](diffhunk://#diff-2b9647ff38275a8b14f0d5f0b393203b7a1dde857dbb5015210fbb805955580dR65-R68))