### PR TITLE
feat: Adjust memory specifications to 1GB constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ ChanUX is a simple operating system kernel written in C and x86 assembly. This p
 
 ### Development Environment
 - Linux or macOS (WSL2 for Windows)
-- At least 4GB RAM
-- 1GB free disk space
+- At least 1GB RAM
+- 1GB total disk space
 
 ## Project Structure
 
@@ -222,7 +222,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - VGA Text Buffer: Direct memory access at 0xB8000
 - PMM Bitmap: Located at 2MB (0x200000)
 - Page Size: 4KB (4096 bytes)
-- Heap Start: 256MB (0x10000000)
+- Heap Start: 64MB (0x04000000)
 - Initial Heap Size: 1MB
 
 ### Boot Process
@@ -243,7 +243,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
    - Enables paging (CR0.PG = 1)
    - Installs page fault handler
 10. Heap Allocator initializes:
-   - Maps 256 pages (1MB) at 256MB mark
+   - Maps 256 pages (1MB) at 64MB mark
    - Sets up linked list of memory blocks
 11. Timer driver initializes:
    - Configures PIT for 100Hz operation
@@ -297,9 +297,9 @@ This project is licensed under the MIT License - see the LICENSE file for detail
   - Page directory cloning (for process creation)
   - TLB management
 - **Memory Layout**:
-  - 0x00000000-0x3FFFFFFF: Kernel space (1GB)
-  - 0x40000000-0xBFFFFFFF: User space (2GB)
-  - 0xC0000000-0xFFFFFFFF: Reserved (1GB)
+  - 0x00000000-0x07FFFFFF: Kernel space (128MB)
+  - 0x08000000-0x3FFFFFFF: User space (~896MB)
+  - 0x40000000-0x3FFFFFFF: Total addressable (1GB)
 - **API**:
   - `vmm_map_page()` - Map virtual to physical address
   - `vmm_unmap_page()` - Unmap virtual address
@@ -318,9 +318,9 @@ This project is licensed under the MIT License - see the LICENSE file for detail
   - Heap integrity checking
   - Statistics tracking
 - **Memory Layout**:
-  - Start Address: 0x10000000 (256MB)
+  - Start Address: 0x04000000 (64MB)
   - Initial Size: 1MB
-  - Maximum Size: 256MB
+  - Maximum Size: 64MB
   - Minimum Block: 16 bytes
   - Alignment: 8 bytes
 - **API**:

--- a/src/include/heap.h
+++ b/src/include/heap.h
@@ -13,9 +13,9 @@
 #include <stddef.h>
 
 /* Heap configuration */
-#define HEAP_START      0x10000000  /* Heap starts at 256MB */
+#define HEAP_START      0x04000000  /* Heap starts at 64MB */
 #define HEAP_INITIAL_SIZE 0x100000  /* Initial heap size: 1MB */
-#define HEAP_MAX_SIZE   0x10000000  /* Maximum heap size: 256MB */
+#define HEAP_MAX_SIZE   0x04000000  /* Maximum heap size: 64MB */
 #define HEAP_MIN_BLOCK_SIZE 16      /* Minimum allocatable block */
 #define HEAP_ALIGNMENT  8           /* Memory alignment requirement */
 

--- a/src/include/vmm.h
+++ b/src/include/vmm.h
@@ -15,10 +15,10 @@
 
 /* Virtual memory regions */
 #define KERNEL_VIRT_BASE    0x00000000  /* Kernel starts at 0 (identity mapped) */
-#define KERNEL_HEAP_START   0x10000000  /* Kernel heap starts at 256MB */
-#define KERNEL_HEAP_SIZE    0x10000000  /* 256MB for kernel heap */
-#define USER_SPACE_START    0x40000000  /* User space starts at 1GB */
-#define USER_SPACE_END      0xBFFFF000  /* User space ends at 3GB */
+#define KERNEL_HEAP_START   0x04000000  /* Kernel heap starts at 64MB */
+#define KERNEL_HEAP_SIZE    0x04000000  /* 64MB for kernel heap */
+#define USER_SPACE_START    0x08000000  /* User space starts at 128MB */
+#define USER_SPACE_END      0x3FFFF000  /* User space ends at ~1GB */
 
 /* Initialize the virtual memory manager */
 void vmm_init(void);

--- a/src/kernel/gdt.c
+++ b/src/kernel/gdt.c
@@ -91,28 +91,28 @@ void gdt_install() {
     gdt_set_gate(0, 0, 0, 0, 0);
     
     /* Kernel code segment
-     * Base: 0, Limit: 4GB, Access: 0x9A (present, ring 0, code segment, readable)
+     * Base: 0, Limit: 1GB, Access: 0x9A (present, ring 0, code segment, readable)
      * Granularity: 0xCF (4KB pages, 32-bit mode)
      */
-    gdt_set_gate(1, 0, 0xFFFFFFFF, 0x9A, 0xCF);
+    gdt_set_gate(1, 0, 0x3FFFFFFF, 0x9A, 0xCF);
     
     /* Kernel data segment
-     * Base: 0, Limit: 4GB, Access: 0x92 (present, ring 0, data segment, writable)
+     * Base: 0, Limit: 1GB, Access: 0x92 (present, ring 0, data segment, writable)
      * Granularity: 0xCF (4KB pages, 32-bit mode)
      */
-    gdt_set_gate(2, 0, 0xFFFFFFFF, 0x92, 0xCF);
+    gdt_set_gate(2, 0, 0x3FFFFFFF, 0x92, 0xCF);
     
     /* User code segment
-     * Base: 0, Limit: 4GB, Access: 0xFA (present, ring 3, code segment, readable)
+     * Base: 0, Limit: 1GB, Access: 0xFA (present, ring 3, code segment, readable)
      * Granularity: 0xCF (4KB pages, 32-bit mode)
      */
-    gdt_set_gate(3, 0, 0xFFFFFFFF, 0xFA, 0xCF);
+    gdt_set_gate(3, 0, 0x3FFFFFFF, 0xFA, 0xCF);
     
     /* User data segment
-     * Base: 0, Limit: 4GB, Access: 0xF2 (present, ring 3, data segment, writable)
+     * Base: 0, Limit: 1GB, Access: 0xF2 (present, ring 3, data segment, writable)
      * Granularity: 0xCF (4KB pages, 32-bit mode)
      */
-    gdt_set_gate(4, 0, 0xFFFFFFFF, 0xF2, 0xCF);
+    gdt_set_gate(4, 0, 0x3FFFFFFF, 0xF2, 0xCF);
     
     /* Load the GDT into the GDTR register */
     gdt_flush((uint32_t)&gp);


### PR DESCRIPTION
 ## Summary
  - Adjusted memory specifications to support systems with 1GB RAM
  - Updated GDT segment limits from 4GB to 1GB
  - Reconfigured virtual memory layout to fit within 1GB constraint

  ## Changes

  ### Memory Layout Adjustments
  - **GDT Segments**: Changed all segment limits from 0xFFFFFFFF (4GB) to 0x3FFFFFFF (1GB)
  - **Kernel Heap**:
    - Start address: 256MB → 64MB (0x04000000)
    - Maximum size: 256MB → 64MB
  - **User Space**:
    - Start address: 1GB → 128MB (0x08000000)
    - End address: 3GB → ~1GB (0x3FFFF000)

  ### Documentation Updates
  - Updated hardware requirements from 4GB to 1GB RAM
  - Modified memory layout documentation in README
  - Updated all related comments in code

  ## Motivation
  This change makes ChanUX suitable for resource-constrained environments and embedded systems with limited memory. The new memory layout efficiently utilizes the
  available 1GB:
  - 0-128MB: Kernel space (including kernel code, data, and heap)
  - 128MB-1GB: User space for applications

  ## Test Plan
  - [x] Verify kernel builds successfully with new configurations
  - [ ] Test boot process in QEMU with 1GB memory limit
  - [ ] Verify PMM correctly detects and manages 1GB memory
  - [ ] Test heap allocation within new 64MB limit
  - [ ] Ensure user space programs can run in the new memory range

  ## Impact
  - Breaking change for systems expecting the previous 4GB memory layout
  - All kernel modules will operate within the new memory constraints
  - Future disk driver implementations should respect 1GB disk limit

  🤖 Generated with [Claude Code](https://claude.ai/code)